### PR TITLE
Fix tiny command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make bin
 ## wof-libpostal-server
 
 ```
-$> .bin/wof-libpostal-server -options
+$> ./bin/wof-libpostal-server -options
 
 Usage of wof-libpostal-server:
   -gracehttp.log


### PR DESCRIPTION
To fix a tiny command error that found in README.md