### PR TITLE
Bugfix to get `make bin` running on FreeBSD 11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-CWD=$(shell pwd)
-GOPATH := $(CWD)
+export GOPATH=${PWD}
 
 prep:
 	if test -d pkg; then rm -rf pkg; fi


### PR DESCRIPTION
without this fix you will get:

% make bin
if test -d pkg; then rm -rf pkg; fi
if test -d src; then rm -rf src; fi
if test -d src; then rm -rf src; fi
cp -r vendor src
mkdir -p src/github.com/whosonfirst/go-whosonfirst-libpostal
cp -r http src/github.com/whosonfirst/go-whosonfirst-libpostal/
cmd/wof-libpostal-server.go:6:2: cannot find package "github.com/facebookgo/grace/gracehttp" in any of:
	/usr/local/go/src/github.com/facebookgo/grace/gracehttp (from $GOROOT)
	/home/deploy/go/src/github.com/facebookgo/grace/gracehttp (from $GOPATH)
cmd/wof-libpostal-server.go:7:2: cannot find package "github.com/whosonfirst/go-whosonfirst-libpostal/http" in any of:
	/usr/local/go/src/github.com/whosonfirst/go-whosonfirst-libpostal/http (from $GOROOT)
	/home/deploy/go/src/github.com/whosonfirst/go-whosonfirst-libpostal/http (from $GOPATH)
cmd/wof-libpostal-server.go:8:2: cannot find package "github.com/whosonfirst/go-whosonfirst-log" in any of:
	/usr/local/go/src/github.com/whosonfirst/go-whosonfirst-log (from $GOROOT)
	/home/deploy/go/src/github.com/whosonfirst/go-whosonfirst-log (from $GOPATH)
*** Error code 1

Stop.
make: stopped in /home/deploy/go-whosonfirst-libpostal